### PR TITLE
Add Jenkinsfile and update container so it may be run via Jenkins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /src
 ARG HUGO_BASEURL="http://localhost:1313"
 ENV HUGO_BASEURL ${BUILD_COMMAND}
 
-# The entrypoint script supports commands "build", "server", or "bash".
+# The entrypoint script supports commands "build", "server", or pass-through to sh.
 ENTRYPOINT ["/src/entrypoint.sh"]
 
 # Default operation

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,23 @@
+pipeline {
+  agent {
+    node {
+      label 'project:any'
+    }
+  }
+  parameters {
+    choice(choices: ['development', 'staging', 'production'], description: 'deployment environment', name: 'DEPLOY_TIER')
+  }
+  stages {
+    stage('Build') {
+      agent {
+        dockerfile {
+          args '-u root:root -v "${WORKSPACE}":/src -e "HUGO_BASEURL=/updates"'
+          reuseNode true
+        }
+      }
+      steps {
+        sh "/src/entrypoint.sh build"
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -111,10 +111,10 @@ docker-compose run hugo build --buildDrafts
 
 ## Debugging the container
 
-If the need arises, you may get a bash prompt in the container:
+If the need arises, you may run arbitrary commands in the container, such as a bash shell:
 
 ```bash
-docker-compose run hugo bash
+docker-compose run hugo bash -l
 ```
 
 # Instructions for R users

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -eux -o pipefail
+
 COMMAND=$1
 ARGS=${@:2}
 
@@ -16,10 +18,7 @@ case ${COMMAND} in
         npm install
         npm run watch & cd /src && hugo server --bind=0.0.0.0 ${ARGS}
         ;;
-    bash)
-        bash -l
-        ;;
     *)
-        echo "Unknown entrypoint '${COMMAND}'. Usage: entrypoint.sh build|server|bash"
+        exec "$@"
         ;;
 esac


### PR DESCRIPTION
I removed the publish step for this - it just includes the Docker build portion. This can be used if we get the Docker plugin on the right Jenkins instance or deploy to an S3 bucket.